### PR TITLE
Add ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# SecureDrop Debian Packaging Guidelines
+
+[![Documentation Status](https://readthedocs.org/projects/securedrop-debian-packaging-guide/badge/?version=latest)](https://securedrop-debian-packaging-guide.readthedocs.io/en/latest/?badge=latest)
+
+This repository contains documentation for packagers of SecureDrop repositories.


### PR DESCRIPTION
Just set up this repo to build on ReadTheDocs off the `master` branch: https://securedrop-debian-packaging-guide.readthedocs.io/en/latest/