### PR TITLE
Updates with the exception for python-dateutil package

### DIFF
--- a/docs/debian101.rst
+++ b/docs/debian101.rst
@@ -243,7 +243,8 @@ Import points to remember for this file.
 
 - Double check the Build-Depends lines
 - Add all the Debian packages this package is depending on the ``Depends`` line
-
+- Please make sure to add all the native libraries this package is dependent on
+are in the ``Depends`` line.
 
 Editing the copyright file
 ---------------------------

--- a/docs/internalpackaging.rst
+++ b/docs/internalpackaging.rst
@@ -15,7 +15,7 @@ Install computepipfilehash tool
 
 
 The above command will install `computepipfilehash
-<https://github.com/kushaldas/computepipfilehash>`_ tool. Use ``0.0.2``
+<https://github.com/kushaldas/computepipfilehash>`_ tool. Use ``0.0.3``
 version for this guide.
 
 
@@ -59,6 +59,11 @@ Finally, we can build the missing binary wheels from the sources.
 
     pip3 wheel --no-index --find-links ./localwheels/ -w ./localwheels/ -r requirements-build.txt
 
+
+.. note:: The `python-dateutil` package is an exception as it we have to build the wheel manually first. This is
+          because the way the `setup.py` of the said project works.
+
+          ``pip3 install wheel`` and then ``pip3 wheel localwheels/python-dateutil-2.7.5.tar.gz``
 
 
 The above command will build the wheels in the ``./localwheels/`` directory.


### PR DESCRIPTION
Adds a note for the `python-dateutil` package as that needs to be manually built if required.